### PR TITLE
fixing a small spacing issue

### DIFF
--- a/templates/index.jade
+++ b/templates/index.jade
@@ -17,5 +17,5 @@ block content
   section#event
     h2 Next event:
     h3 Tuesday, March 8th, 2016 - 6:30pm to 8:30pm
-      em Nodebots Office Hours
+      em  Nodebots Office Hours
     p Do you need a little help getting up and running with Nodebots? Bring your own hardware and we'll help you get set up! There will be no presentations; just some folks hanging out to help you get unblocked.


### PR DESCRIPTION
Just a small typo in the spacing.  Jade has a very edges around spaces that you have to be careful about.  Otherwise, the copy looks good.
